### PR TITLE
fix(ci): Avoid looking for submodules

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -18,10 +18,6 @@ jobs:
         sudo apt-get install python3-distutils libfastjson-dev libcurl4-gnutls-dev libssl-dev -y
 
     - uses: actions/checkout@v2
-      with:
-        submodules: true
-        # This can be removed once access-sdk is made public
-        token: ${{ secrets.PAT }}
 
     - name: Run CMake
       uses: lukka/run-cmake@v2.5


### PR DESCRIPTION
No submodules are used in this repo, so we don't need to pass the `submodules` and `token` parameters